### PR TITLE
Do not call method that was removed in Python 3.9 in six

### DIFF
--- a/projects/bitcoin-core/build.sh
+++ b/projects/bitcoin-core/build.sh
@@ -59,21 +59,29 @@ export CPPFLAGS="-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -DBOOST_M
 
 # Build the fuzz targets
 
-sed -i "s|PROVIDE_FUZZ_MAIN_FUNCTION|NEVER_PROVIDE_MAIN_FOR_OSS_FUZZ|g" "./configure.ac"
-./autogen.sh
+sed -i "s|PROVIDE_FUZZ_MAIN_FUNCTION|NEVER_PROVIDE_MAIN_FOR_OSS_FUZZ|g" "./src/test/fuzz/util/CMakeLists.txt"
 
 # OSS-Fuzz will provide CC, CXX, etc. So only set:
-# * --enable-fuzz, see https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md
-# * CONFIG_SITE, see https://github.com/bitcoin/bitcoin/blob/master/depends/README.md
+# * -DBUILD_FOR_FUZZING=ON, see https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md
+# * --toolchain, see https://github.com/bitcoin/bitcoin/blob/master/depends/README.md
+EXTRA_BUILD_OPTIONS=
 if [ "$SANITIZER" = "memory" ]; then
   # _FORTIFY_SOURCE is not compatible with MSAN.
-  export CPPFLAGS="${CPPFLAGS} -U_FORTIFY_SOURCE"
+  EXTRA_BUILD_OPTIONS="-DAPPEND_CPPFLAGS='-U_FORTIFY_SOURCE'"
 fi
 
-CONFIG_SITE="$PWD/depends/$BUILD_TRIPLET/share/config.site" ./configure --enable-fuzz SANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE"
-make -j$(nproc)
+cmake -B build_fuzz \
+  --toolchain depends/${BUILD_TRIPLET}/toolchain.cmake \
+  `# Setting these flags to an empty string ensures that the flags set by an OSS-Fuzz environment remain unaltered` \
+  -DCMAKE_C_FLAGS_RELWITHDEBINFO="" \
+  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="" \
+  -DBUILD_FOR_FUZZING=ON \
+  -DSANITIZER_LDFLAGS="$LIB_FUZZING_ENGINE" \
+  $EXTRA_BUILD_OPTIONS
 
-WRITE_ALL_FUZZ_TARGETS_AND_ABORT="/tmp/a" "./src/test/fuzz/fuzz" || true
+cmake --build build_fuzz -j$(nproc)
+
+WRITE_ALL_FUZZ_TARGETS_AND_ABORT="/tmp/a" "./build_fuzz/src/test/fuzz/fuzz" || true
 readarray FUZZ_TARGETS < "/tmp/a"
 if [ -n "${OSS_FUZZ_CI-}" ]; then
   # When running in CI, check the first targets only to save time and disk space
@@ -85,16 +93,16 @@ fi
 # executable with a "magic string" as the name of the fuzz target.
 #
 # An alternative to mocking the string in the finished binary would be to
-# replace the string in the source code and re-invoke 'make'. This is slower,
+# replace the string in the source code and re-invoke 'cmake --build'. This is slower,
 # so use the hack.
 export MAGIC_STR="b5813eee2abc9d3358151f298b75a72264ffa119d2f71ae7fefa15c4b70b4bc5b38e87e3107a730f25891ea428b2b4fabe7a84f5bfa73c79e0479e085e4ff157"
 sed -i "s|std::getenv(\"FUZZ\")|\"$MAGIC_STR\"|g" "./src/test/fuzz/fuzz.cpp"
-make -j$(nproc)
+cmake --build build_fuzz -j$(nproc)
 
 # Replace the magic string with the actual name of each fuzz target
 for fuzz_target in ${FUZZ_TARGETS[@]}; do
   df --human-readable ./src
-  python3 -c "c_str_target=b\"${fuzz_target}\x00\";c_str_magic=b\"$MAGIC_STR\";dat=open('./src/test/fuzz/fuzz','rb').read();dat=dat.replace(c_str_magic, c_str_target+c_str_magic[len(c_str_target):]);open(\"$OUT/$fuzz_target\",'wb').write(dat)"
+  python3 -c "c_str_target=b\"${fuzz_target}\x00\";c_str_magic=b\"$MAGIC_STR\";dat=open('./build_fuzz/src/test/fuzz/fuzz','rb').read();dat=dat.replace(c_str_magic, c_str_target+c_str_magic[len(c_str_target):]);open(\"$OUT/$fuzz_target\",'wb').write(dat)"
 
   chmod +x "$OUT/$fuzz_target"
   (

--- a/projects/chrono/project.yaml
+++ b/projects/chrono/project.yaml
@@ -1,0 +1,8 @@
+homepage: "https://github.com/chronotope/chrono"
+main_repo: "https://github.com/chronotope/chrono.git"
+language: rust
+primary_contact: "dirkjan@ochtman.nl"
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer

--- a/projects/llamacpp/build.sh
+++ b/projects/llamacpp/build.sh
@@ -47,6 +47,7 @@ FLAGS="-std=c++11 -Iggml/include -Iggml/src -Iinclude -Isrc -Icommon -I./ -DNDEB
 cp fuzzers/*.dict $OUT/
 
 $CXX $LIB_FUZZING_ENGINE $CXXFLAGS ${FLAGS} ${OBJ_FILES} fuzzers/fuzz_json_to_grammar.cpp -o $OUT/fuzz_json_to_grammar
+$CXX $LIB_FUZZING_ENGINE $CXXFLAGS ${FLAGS} ${OBJ_FILES} fuzzers/fuzz_apply_template.cpp -o $OUT/fuzz_apply_template
 $CXX $LIB_FUZZING_ENGINE $CXXFLAGS ${FLAGS} ${OBJ_FILES} fuzzers/fuzz_grammar.cpp -o $OUT/fuzz_grammar
 
 # Create a corpus for load_model_fuzzer

--- a/projects/llamacpp/fuzzers/fuzz_apply_template.cpp
+++ b/projects/llamacpp/fuzzers/fuzz_apply_template.cpp
@@ -1,0 +1,39 @@
+/* Copyright 2024 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "llama.h"
+#include <fuzzer/FuzzedDataProvider.h>
+
+char buf[4096];
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  FuzzedDataProvider fuzzed_data(data, size);
+
+  std::string p1 = fuzzed_data.ConsumeRandomLengthString();
+  std::string p2 = fuzzed_data.ConsumeRandomLengthString();
+  std::string p3 = fuzzed_data.ConsumeRandomLengthString();
+  std::string p4 = fuzzed_data.ConsumeRandomLengthString();
+  std::string p5 = fuzzed_data.ConsumeRandomLengthString();
+  std::string p6 = fuzzed_data.ConsumeRandomLengthString();
+  std::string p7 = fuzzed_data.ConsumeRandomLengthString();
+
+  llama_chat_message conversation[] = {
+      {"system", p2.c_str()},    {"user", p3.c_str()},
+      {"assistant", p4.c_str()}, {"user", p5.c_str()},
+      {"assistant", p6.c_str()}, {"user", p7.c_str()},
+  };
+  size_t message_count = 6;
+
+  llama_chat_apply_template(nullptr, p1.c_str(), conversation, message_count,
+                            true, buf, 4096);
+  return 0;
+}

--- a/projects/six/fuzz_six.py
+++ b/projects/six/fuzz_six.py
@@ -55,9 +55,6 @@ def TestOneInput(data):
   except (TypeError, UnicodeDecodeError):
     pass
 
-  six.moves.html_parser.HTMLParser().unescape(
-      fdp.ConsumeUnicodeNoSurrogates(fdp.ConsumeIntInRange(1, 1024)))
-
 
 def main():
   atheris.instrument_all()


### PR DESCRIPTION
An attempt to help https://github.com/google/oss-fuzz/pull/12027

You linked to a log with a failure for six - https://oss-fuzz-gcb-logs.storage.googleapis.com/log-4180e85e-4b31-4442-849a-2188343052bc.txt
> AttributeError: 'HTMLParser' object has no attribute 'unescape'

The failure makes sense as a result of the Python version upgrade, since in Python 3.9, 'unescape' was removed from HTMLParser - https://docs.python.org/3/whatsnew/3.9.html#porting-to-python-3-9
> The unescape() method in the [html.parser.HTMLParser](https://docs.python.org/3/library/html.parser.html#html.parser.HTMLParser) class has been removed (it was deprecated since Python 3.4).

However, if you look at the six source code, `unescape` isn't even used. HTMLParser is sure, but that's it. So I think the problematic code can be removed from fuzz_six.py - the method is gone in Python >= 3.9, and Python 3.8 is EOL, so there's no need to continue testing it.